### PR TITLE
refactor footer, sign in page, topiclist and replybox

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,7 +19,7 @@ import * as Setting from "./Setting";
 import { Switch, Route } from "react-router-dom";
 import TopicPage from "./TopicPage";
 import PageHeader from "./Header";
-import Footer from "./Footer";
+import PageFooter from "./Footer";
 import RightSigninBox from "./rightbar/RightSigninBox";
 import RightAccountBox from "./rightbar/RightAccountBox";
 import SearchTag from "./main/SearchTag";
@@ -782,7 +782,7 @@ class App extends Component {
             {Setting.PcBrowser ? <div className="sep20" /> : null}
           </div>
         </div>
-        <Footer />
+        <PageFooter BreakpointStage={this.state.BreakpointStage} />
       </div>
     );
   }

--- a/src/App.js
+++ b/src/App.js
@@ -220,19 +220,22 @@ class App extends Component {
           </div>
         </Route>
         <Route exact path="/signin">
-          <div id={pcBrowser ? "Main" : ""}>
-            {pcBrowser ? <div className="sep20" /> : null}
+          {/* <div id={pcBrowser ? "Main" : ""}> */}
+          <div style={{ display: "flex", justifyContent: "center" }}>
+            {/* {pcBrowser ? <div className="sep20" /> : null} */}
             <LazyLoad>
               <SigninBox
                 onSignin={this.onSignin.bind(this)}
                 onSignout={this.onSignout.bind(this)}
                 Casdoor={this.state.casdoor}
+                BreakpointStage={this.state.BreakpointStage}
+                OAuthObjects={this.state.OAuthObjects}
               />
             </LazyLoad>
-            {pcBrowser ? null : <div className="sep5" />}
+            {/* {pcBrowser ? null : <div className="sep5" />}
             {pcBrowser ? null : (
               <RightSigninBox OAuthObjects={this.state.OAuthObjects} />
-            )}
+            )} */}
           </div>
         </Route>
         <Route exact path="/signout">
@@ -746,6 +749,7 @@ class App extends Component {
   }
 
   render() {
+    console.log(window.innerWidth);
     return (
       <div>
         <link
@@ -773,7 +777,7 @@ class App extends Component {
           className={this.state.nodeId}
           onClick={() => this.changeMenuStatus(false)}
         >
-          <div className="content">
+          <div>
             <div id="Leftbar" />
             {Setting.PcBrowser ? <CustomGithubCorner /> : null}
             {Setting.PcBrowser ? this.renderRightbar() : null}

--- a/src/App.js
+++ b/src/App.js
@@ -780,7 +780,7 @@ class App extends Component {
           <div>
             <div id="Leftbar" />
             {Setting.PcBrowser ? <CustomGithubCorner /> : null}
-            {Setting.PcBrowser ? this.renderRightbar() : null}
+            {/* {Setting.PcBrowser ? this.renderRightbar() : null} */}
             {this.renderMain()}
             <div className="c" />
             {Setting.PcBrowser ? <div className="sep20" /> : null}

--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -27,13 +27,13 @@ class Avatar extends React.Component {
   render() {
     let style;
     if (this.props.size === "small") {
-      style = { width: "24px", height: "24px" };
+      style = { width: "24px", height: "24px", borderRadius: "24px" };
     } else if (this.props.size === "large") {
-      style = { width: "73px", height: "73px" };
+      style = { width: "73px", height: "73px", borderRadius: "73px" };
     } else if (this.props.size === "middle") {
-      style = { width: "36px", height: "36px" };
+      style = { width: "36px", height: "36px", borderRadius: "36px" };
     } else {
-      style = { width: "48px", height: "48px" };
+      style = { width: "48px", height: "48px", borderRadius: "48px" };
     }
 
     let src;

--- a/src/Conf.js
+++ b/src/Conf.js
@@ -63,3 +63,7 @@ export const WikiUrl = "https://casdoor.org/docs/overview";
 export const FooterSlogan1 = "World is powered by code";
 
 export const FooterSlogan2 = "♥ Do have faith in what you're doing.";
+
+export const SiteSlogan = "Casbin = way to authorization";
+
+export const SiteDescription = "A place for Casbin developers and users";

--- a/src/Conf.js
+++ b/src/Conf.js
@@ -59,3 +59,7 @@ export const NotificationAutoUpdatePeriod = 10; // second
 export const DefaultTopicPageReplyNum = 100;
 
 export const WikiUrl = "https://casdoor.org/docs/overview";
+
+export const FooterSlogan1 = "World is powered by code";
+
+export const FooterSlogan2 = "♥ Do have faith in what you're doing.";

--- a/src/Footer.css
+++ b/src/Footer.css
@@ -1,0 +1,13 @@
+.titles {
+  color: black !important;
+}
+
+.titles:hover {
+  text-decoration: underline;
+  color: #185198;
+}
+
+.slash {
+  padding: 0 5px;
+  color: gray;
+}

--- a/src/Footer.js
+++ b/src/Footer.js
@@ -19,8 +19,19 @@ import * as BasicBackend from "./backend/BasicBackend";
 import { Link, withRouter } from "react-router-dom";
 import moment from "moment";
 import i18next from "i18next";
+import { Layout } from "antd";
 
-class Footer extends React.Component {
+import Container from "./components/container";
+import { createFromIconfontCN } from "@ant-design/icons";
+
+import "./Footer.css";
+
+const IconFont = createFromIconfontCN({
+  scriptUrl: "//at.alicdn.com/t/font_2717339_hu7ls0q10p.js",
+});
+const { Footer } = Layout;
+
+class PageFooter extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -103,104 +114,118 @@ class Footer extends React.Component {
     const jfkTime = moment().utcOffset(-4).format("HH:mm");
 
     return (
-      <div id="Bottom">
-        <div className="content">
-          <div className="inner">
-            <div className="sep10" />
-            <div className="fr">
-              <a href="https://www.digitalocean.com/" target="_blank">
-                <div id="logoFooter" />
-              </a>
-            </div>
-            {/*<div className="fr">*/}
-            {/*  <a href="https://casbin.org" target="_blank">*/}
-            {/*    <div className="footer-logo" />*/}
-            {/*  </a>*/}
-            {/*</div>*/}
-            <strong>
-              <Link to="/about" className="dark" target="_self">
+      <Footer
+        style={{
+          justifyContent: "center",
+          backgroundColor: "#f4f4f4",
+          display: "flex",
+          alignItems: "center",
+          position: "sticky",
+          padding: "0px",
+        }}
+      >
+        <Container BreakpointStage={this.props.BreakpointStage}>
+          <div className="fr" style={{ marginRight: "10px" }}>
+            <a href="https://www.digitalocean.com/" target="_blank">
+              <div id="logoFooter" />
+            </a>
+          </div>
+          {/*<div className="fr">*/}
+          {/*  <a href="https://casbin.org" target="_blank">*/}
+          {/*    <div className="footer-logo" />*/}
+          {/*  </a>*/}
+          {/*</div>*/}
+          <div style={{ flex: "1", alignItems: "center", fontSize: "18px" }}>
+            <div style={{ textAlign: "center" }}>
+              <Link to="/about" target="_self" className="titles">
                 {i18next.t("footer:About")}
-              </Link>{" "}
-              &nbsp; <span className="snow">·</span> &nbsp;{" "}
-              <Link to="/faq" className="dark" target="_self">
+              </Link>
+              <span className="slash">/</span>
+              <Link to="/faq" target="_self" className="titles">
                 FAQ
-              </Link>{" "}
-              &nbsp; <span className="snow">·</span> &nbsp;{" "}
-              <Link to="/api" className="dark" target="_self">
+              </Link>
+              <span className="slash">/</span>
+              <Link to="/api" target="_self" className="titles">
                 API
-              </Link>{" "}
-              &nbsp; <span className="snow">·</span> &nbsp;{" "}
-              <Link to="/mission" className="dark" target="_self">
+              </Link>
+              <span className="slash">/</span>
+              <Link to="/mission" target="_self" className="titles">
                 {i18next.t("footer:Mission")}
-              </Link>{" "}
-              &nbsp; <span className="snow">·</span> &nbsp;{" "}
-              <Link to="/advertise" className="dark" target="_self">
+              </Link>
+              <span className="slash">/</span>
+              <Link to="/advertise" target="_self" className="titles">
                 {i18next.t("footer:Advertise")}
-              </Link>{" "}
-              &nbsp; <span className="snow">·</span> &nbsp;{" "}
-              <Link to="/advertise/2019.html" className="dark" target="_self">
+              </Link>
+              <span className="slash">/</span>
+              <Link to="/advertise/2019.html" target="_self" className="titles">
                 {i18next.t("footer:Thanks")}
-              </Link>{" "}
-              &nbsp; <span className="snow">·</span> &nbsp;{" "}
-              <Link to="/tools" className="dark" target="_self">
+              </Link>
+              <span className="slash">/</span>
+              <Link to="/tools" target="_self" className="titles">
                 {i18next.t("footer:Tools")}
-              </Link>{" "}
-              &nbsp; <span className="snow">·</span> &nbsp; {this.state.online}{" "}
-              {i18next.t("footer:Online")}
-            </strong>{" "}
-            &nbsp;{" "}
-            <span className="fade">
-              {i18next.t("footer:Highest")} {this.state.highest}
-            </span>{" "}
-            &nbsp; <span className="snow">·</span> &nbsp;{" "}
-            <Link
-              to={{
-                pathname: "/select/language",
-                query: { previous: this.props.location.pathname },
-              }}
-              className="f11"
-            >
-              <img
-                src={Setting.getStatic("/static/img/language.png")}
-                width="16"
-                align="absmiddle"
-                id="ico-select-language"
-              />{" "}
-              &nbsp; {i18next.t("footer:Select Language")}
-            </Link>
-            &nbsp; <span className="snow">·</span> &nbsp;{" "}
-            <Link to="/select/editorType" className="f11">
-              <img
-                src={Setting.getStatic("/static/img/editType.png")}
-                width="16"
-                align="absmiddle"
-                id="ico-select-editorType"
-              />{" "}
-              &nbsp; {i18next.t("footer:Select Editor")}
-            </Link>
-            <div className="sep20" />
-            {i18next.t("footer:Community of Creators")}
-            <div className="sep5" />
-            World is powered by code
-            <div className="sep20" />
-            <span className="small fade">
-              VERSION:{" "}
+              </Link>
+            </div>
+
+            <div style={{ textAlign: "center" }}>
+              <span style={{ marginRight: "30px" }}>
+                {this.state.online} {i18next.t("footer:Online")}
+                <span style={{ marginLeft: "10px" }}>
+                  {i18next.t("footer:Highest")}
+                  {":"} {this.state.highest}
+                </span>
+              </span>
+              {i18next.t("footer:Community of Creators")}
+              <div style={{ color: "gray" }}>{Conf.FooterSlogan1}</div>
+            </div>
+            <div style={{ textAlign: "center", color: "gray" }}>
+              VERSION:
               <a
                 href={`${Conf.GithubRepo}/commit/${this.state.version}`}
                 target="_blank"
               >
                 {this.state.version.substring(0, 7)}
-              </a>{" "}
-              · {loadingTime}ms · UTC {utcTime} · PVG {pvgTime} · LAX {laxTime}{" "}
-              · JFK {jfkTime}
-              <br />♥ Do have faith in what you're doing.
-            </span>
-            <div className="sep10" />
+              </a>
+              · {loadingTime}ms · UTC {utcTime} · PVG {pvgTime} · LAX {laxTime}·
+              JFK {jfkTime}
+              <br />
+              {Conf.FooterSlogan2}
+            </div>
+            <div style={{ textAlign: "center", marginTop: "10px" }}>
+              <IconFont style={{ fontSize: "25px" }} type="icon-rss" />
+
+              <span style={{ marginLeft: "30px" }}>
+                <Link
+                  to={{
+                    pathname: "/select/language",
+                    query: { previous: this.props.location.pathname },
+                  }}
+                  className="f11"
+                >
+                  <img
+                    src={Setting.getStatic("/static/img/language.png")}
+                    width="16"
+                    align="absmiddle"
+                    id="ico-select-language"
+                  />{" "}
+                  {i18next.t("footer:Select Language")}
+                </Link>
+                &nbsp;
+                <Link to="/select/editorType" className="f11">
+                  <img
+                    src={Setting.getStatic("/static/img/editType.png")}
+                    width="16"
+                    align="absmiddle"
+                    id="ico-select-editorType"
+                  />{" "}
+                  {i18next.t("footer:Select Editor")}
+                </Link>
+              </span>
+            </div>
           </div>
-        </div>
-      </div>
+        </Container>
+      </Footer>
     );
   }
 }
 
-export default withRouter(Footer);
+export default withRouter(PageFooter);

--- a/src/Header.js
+++ b/src/Header.js
@@ -622,7 +622,7 @@ class PageHeader extends React.Component {
           backgroundColor: "white",
           display: "flex",
           alignItems: "center",
-          position: "sticky",
+          position: "relative",
           top: "0",
           padding: "0px",
         }}

--- a/src/Header.js
+++ b/src/Header.js
@@ -24,19 +24,14 @@ import { ServerUrl } from "./Setting";
 import { authConfig } from "./auth/Auth";
 
 import { Layout, Menu, Dropdown, Avatar } from "antd";
-import {
-  createFromIconfontCN,
-  CaretDownOutlined,
-  PlusOutlined,
-  NotificationOutlined,
-} from "@ant-design/icons";
+import { createFromIconfontCN, CaretDownOutlined } from "@ant-design/icons";
 import "./Header.css";
 
 import Container from "./components/container";
 
 const { Header } = Layout;
 const IconFont = createFromIconfontCN({
-  scriptUrl: "//at.alicdn.com/t/font_2717339_gxlfvkk0n8e.js",
+  scriptUrl: "//at.alicdn.com/t/font_2717339_hu7ls0q10p.js",
 });
 class PageHeader extends React.Component {
   constructor(props) {

--- a/src/components/container.js
+++ b/src/components/container.js
@@ -18,7 +18,7 @@ export default class Container extends React.Component {
       <div
         className="container"
         style={{
-          justifyContent: "space-between",
+          justifyContent: "center",
           position: "relative",
           display: "flex",
           width:

--- a/src/main/AllCreatedTopicsBox.css
+++ b/src/main/AllCreatedTopicsBox.css
@@ -1,0 +1,3 @@
+.ant-tabs-nav {
+  margin-bottom: 0px !important;
+}

--- a/src/main/AllCreatedTopicsBox.js
+++ b/src/main/AllCreatedTopicsBox.js
@@ -22,6 +22,11 @@ import TopicList from "./TopicList";
 import * as MemberBackend from "../backend/MemberBackend";
 import i18next from "i18next";
 
+import { Card, Tabs } from "antd";
+
+import "./AllCreatedTopicsBox.css";
+const { TabPane } = Tabs;
+
 class AllCreatedTopicsBox extends React.Component {
   constructor(props) {
     super(props);
@@ -255,7 +260,7 @@ class AllCreatedTopicsBox extends React.Component {
       memberAvatar = this.state.member.avatar;
     }
 
-    return (
+    const origin_return = (
       <div className="box">
         <div className="cell_tabs">
           <div className="fl">
@@ -322,6 +327,27 @@ class AllCreatedTopicsBox extends React.Component {
             </Link>
           </div>
         ) : null}
+      </div>
+    );
+
+    return (
+      <div className="card-container">
+        <Tabs type="card">
+          <TabPane tab={i18next.t("general:Personal Profile")} key="1">
+            <Card></Card>
+          </TabPane>
+          <TabPane tab={i18next.t("general:Topics")} key="2">
+            <TopicList
+              topics={this.state.topics}
+              showNodeName={true}
+              showAvatar={true}
+              timeStandard={"createdTime"}
+            />
+          </TabPane>
+          <TabPane tab={i18next.t("general:Replies")} key="3">
+            <LatestReplyBox member={this.state.member} />
+          </TabPane>
+        </Tabs>
       </div>
     );
   }

--- a/src/main/LatestReplyBox.css
+++ b/src/main/LatestReplyBox.css
@@ -1,0 +1,19 @@
+.list {
+  list-style: none;
+  padding: 15px 25px;
+  text-align: left;
+  background-color: white;
+  border-bottom: 1px solid #f4f4f4;
+}
+
+.topicName:hover {
+  text-decoration: underline;
+}
+
+.title {
+  margin-bottom: 5px;
+}
+
+.body p {
+  margin: 0px;
+}

--- a/src/main/LatestReplyBox.js
+++ b/src/main/LatestReplyBox.js
@@ -19,6 +19,8 @@ import { withRouter, Link } from "react-router-dom";
 import PageColumn from "./PageColumn";
 import i18next from "i18next";
 
+import "./LatestReplyBox.css";
+
 const ReactMarkdown = require("react-markdown");
 const pangu = require("pangu");
 
@@ -118,57 +120,33 @@ class LatestReplyBox extends React.Component {
 
   renderReplies(reply) {
     return (
-      <div>
-        <div className="dock_area">
-          <table cellPadding="0" cellSpacing="0" border="0" width="100%">
-            <tbody>
-              <tr>
-                <td
-                  style={{
-                    padding: "10px 15px 8px 15px",
-                    fontSize: "12px",
-                    textAlign: "left",
-                  }}
-                >
-                  <div className="fr">
-                    <span className="fade">
-                      {Setting.getPrettyDate(reply.replyTime)}
-                    </span>
-                  </div>
-                  <span className="gray">
-                    {i18next.t("member:replied")}{" "}
-                    <Link to={`/member/${reply.author}`}> {reply.author} </Link>{" "}
-                    {i18next.t("member:'s topic")}{" "}
-                    <span className="chevron">›</span>{" "}
-                    <Link to={`/go/${reply.nodeId}`}> {reply.nodeName} </Link>
-                    <span className="chevron">›</span>{" "}
-                    <Link
-                      to={`/t/${reply.topicId}?from=${encodeURIComponent(
-                        window.location.href
-                      )}`}
-                    >
-                      {" "}
-                      {pangu.spacing(reply.topicTitle)}{" "}
-                    </Link>
-                  </span>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+      <li className="list">
+        <div className="title">
+          <span className="topicName">
+            <Link
+              to={`/t/${reply.topicId}?from=${encodeURIComponent(
+                window.location.href
+              )}`}
+            >
+              {pangu.spacing(reply.topicTitle)}
+            </Link>
+          </span>{" "}
+          <span className="info">
+            {"at "}
+            {Setting.getPrettyDate(reply.replyTime)}
+          </span>
         </div>
-        <div className="inner">
-          <div className="reply_content">
-            <ReactMarkdown
-              renderers={{
-                image: Setting.renderImage,
-                link: Setting.renderLink,
-              }}
-              source={Setting.getFormattedContent(reply.replyContent, true)}
-              escapeHtml={false}
-            />
-          </div>
+        <div className="body">
+          <ReactMarkdown
+            renderers={{
+              image: Setting.renderImage,
+              link: Setting.renderLink,
+            }}
+            source={Setting.getFormattedContent(reply.replyContent, true)}
+            escapeHtml={false}
+          />
         </div>
-      </div>
+      </li>
     );
   }
 
@@ -206,22 +184,11 @@ class LatestReplyBox extends React.Component {
     }
 
     return (
-      <div className="box">
-        <div className="cell">
-          <span className="gray">{`${this.state.memberId}${i18next.t(
-            "member:'s latest replies"
-          )}`}</span>
-        </div>
+      <ul style={{ margin: "0" }}>
         {this.state.replies?.map((reply) => {
           return this.renderReplies(reply);
         })}
-        <div className="inner">
-          <span className="chevron">»</span>{" "}
-          <Link to={`/member/${this.state.memberId}/replies`}>{`${
-            this.state.memberId
-          }${i18next.t("member:'s more replies")}`}</Link>
-        </div>
-      </div>
+      </ul>
     );
   }
 }

--- a/src/main/MemberBox.js
+++ b/src/main/MemberBox.js
@@ -447,7 +447,6 @@ class MemberBox extends React.Component {
         ) : (
           <div className="sep5" />
         )}
-        <LatestReplyBox member={this.state.member} />
       </span>
     );
   }

--- a/src/main/SigninBox.css
+++ b/src/main/SigninBox.css
@@ -1,0 +1,50 @@
+.stage1 {
+  width: 830px;
+}
+
+.stage2 {
+  width: 700px;
+}
+
+.stage3 {
+  width: 510px;
+}
+
+.stage4 {
+  width: 580px;
+}
+
+.stage5 {
+  padding: 0 20px;
+  width: 100%;
+}
+
+.input {
+  height: calc(1.5em + 1rem + 2px);
+  outline-style: none;
+  border: 1px solid #ced4da;
+  border-radius: 0.3rem;
+  padding: 0.5rem 1rem;
+  margin: 10px 0;
+  width: 100%;
+  font-size: 1.25rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.input:focus {
+  box-shadow: 0 0 0 0.2rem rgb(34 117 218 / 8%);
+}
+
+.button {
+  height: calc(1.5em + 1rem + 2px);
+  border-radius: 0.3rem;
+  font-size: 1.3rem;
+  margin-top: 10px;
+}
+.title {
+  font-size: 25px;
+  font-weight: 400;
+  margin-bottom: 10px;
+  text-align: left;
+}

--- a/src/main/SigninBox.js
+++ b/src/main/SigninBox.js
@@ -23,6 +23,13 @@ import { withRouter } from "react-router-dom";
 import i18next from "i18next";
 import { AuthConfig } from "../Conf";
 
+import { Button, Card, Alert } from "antd";
+
+import { authConfig } from "../auth/Auth";
+import Container from "../components/container";
+import * as Auth from "../auth/Auth";
+import "./SigninBox.css";
+import * as Conf from "../Conf";
 class SigninBox extends React.Component {
   constructor(props) {
     super(props);
@@ -110,26 +117,18 @@ class SigninBox extends React.Component {
     }
 
     return (
-      <div className="problem" onClick={this.clearMessage.bind(this)}>
-        {i18next.t(
+      <Alert
+        style={{ textAlign: "left" }}
+        message={i18next.t(
           "error:Please resolve the following issues before submitting"
         )}
-        <ul>
-          {problems.map((problem, i) => {
-            if (problem === "Please sign out before sign in") {
-              return (
-                <li>
-                  {i18next.t(`error:${this.state.message}`)} &nbsp;{" "}
-                  <a href="#;" onClick={() => this.signOut()}>
-                    {i18next.t("signout:Click to sign out")}
-                  </a>
-                </li>
-              );
-            }
-            return <li>{i18next.t(`error:${problem}`)}</li>;
-          })}
-        </ul>
-      </div>
+        description={problems.map((problem, i) => {
+          return "· " + i18next.t(`error:${problem}`);
+        })}
+        type="warning"
+        closable
+        showIcon
+      />
     );
   }
 
@@ -139,98 +138,231 @@ class SigninBox extends React.Component {
     }
 
     return (
-      <div className="message" onClick={this.clearMessage.bind(this)}>
-        <li className="fa fa-exclamation-triangle" />
-        &nbsp;{" "}
-        {i18next.t(
+      <Alert
+        style={{ textAlign: "left" }}
+        message={i18next.t(
           "error:We had a problem when you signed in, please try again"
         )}
+        type="error"
+        showIcon
+        closable
+      />
+    );
+  }
+
+  redirectTo(link) {
+    window.location.href = link;
+  }
+
+  renderWechatSignin(link) {
+    return (
+      <div className="cell" style={{ textAlign: "center" }}>
+        <div className="signin_method" onClick={() => this.redirectTo(link)}>
+          <div className="signin_method_icon signin_method_wechat" />
+          <div className="signin_method_label" style={{ width: 140 }}>
+            {i18next.t("signin:Sign in with WeChat")}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  renderGoogleSignin(link) {
+    return (
+      <div className="cell" style={{ textAlign: "center" }}>
+        <div className="signin_method" onClick={() => this.redirectTo(link)}>
+          <div className="signin_method_icon signin_method_google" />
+          <div className="signin_method_label" style={{ width: 140 }}>
+            {i18next.t("signin:Sign in with Google")}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  renderGithubSignin(link) {
+    return (
+      <div className="cell" style={{ textAlign: "center" }}>
+        <div className="signin_method" onClick={() => this.redirectTo(link)}>
+          <div className="signin_method_icon signin_method_github" />
+          <div className="signin_method_label" style={{ width: 140 }}>
+            {i18next.t("signin:Sign in with Github")}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  renderQQSignin(link) {
+    return (
+      <div className="cell" style={{ textAlign: "center" }}>
+        <div className="signin_method" onClick={() => this.redirectTo(link)}>
+          <div className="signin_method_icon signin_method_qq" />
+          <div className="signin_method_label" style={{ width: 140 }}>
+            {i18next.t("signin:Sign in with QQ")}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  renderProvider() {
+    if (
+      window.location.pathname === "/signin" &&
+      this.props.OAuthObjects !== undefined &&
+      this.props.OAuthObjects !== null &&
+      this.props.OAuthObjects.length !== 0
+    ) {
+      return (
+        <div>
+          <div className="title">{i18next.t("bar:Other Sign In Methods")}</div>
+          {this.props.OAuthObjects.map((obj) => {
+            switch (obj.type) {
+              case "Google":
+                return this.renderGoogleSignin(obj.link);
+              case "GitHub":
+                return this.renderGithubSignin(obj.link);
+              case "WeChat":
+                return this.renderWechatSignin(obj.link);
+              case "QQ":
+                return this.renderQQSignin(obj.link);
+              default:
+                return null;
+            }
+          })}
+        </div>
+      );
+    }
+  }
+
+  renderRightBar() {
+    if (
+      this.props.BreakpointStage == "stage4" ||
+      this.props.BreakpointStage == "stage5"
+    ) {
+      return null;
+    }
+    return (
+      <div>
+        <Card style={{ marginTop: "30px", marginLeft: "40px" }}>
+          <div className="cell">
+            <strong>{Conf.SiteSlogan}</strong>
+            <div className="sep5" />
+            <span className="fade">{Conf.SiteDescription}</span>
+          </div>
+          <div className="sep5" />
+          <ul
+            style={{ listStyle: "none", textAlign: "left", fontSize: "18px" }}
+          >
+            <li>
+              <div style={{ padding: "10px 0" }}>
+                <a href={Auth.getSignupUrl()}>{i18next.t("bar:Sign Up Now")}</a>
+              </div>
+            </li>
+            <li>
+              <div style={{ padding: "10px 0" }}>
+                <a
+                  href={`${AuthConfig.serverUrl}/forget/${AuthConfig.appName}`}
+                >
+                  {i18next.t("general:Forgot Password")}
+                </a>
+              </div>
+            </li>
+          </ul>
+        </Card>
       </div>
     );
   }
 
   render() {
     return (
-      <div className="box">
-        <Header item="Sign In" />
-        {this.renderProblem()}
-        {this.renderMessage()}
-        <div className="cell">
-          <form onSubmit={this.onSignin}>
-            <table cellPadding="5" cellSpacing="0" border="0" width="100%">
-              <tbody>
-                <tr>
-                  <td width="120" align="right">
-                    {i18next.t("general:Username")}
-                  </td>
-                  <td width="auto" align="left">
-                    <input
-                      type="text"
-                      value={this.state.form.information}
-                      onChange={(event) => {
-                        this.updateFormField("information", event.target.value);
-                      }}
-                      className="sl"
-                      name="username"
-                      autoFocus="autofocus"
-                      autoCorrect="off"
-                      spellCheck="false"
-                      autoCapitalize="off"
-                      placeholder={i18next.t(
-                        "general:Username, email address or phone number"
-                      )}
-                      style={{ width: Setting.PcBrowser ? "280px" : "100%" }}
-                    />
-                  </td>
-                </tr>
-                <tr>
-                  <td width="120" align="right">
-                    {i18next.t("general:Password")}
-                  </td>
-                  <td width="auto" align="left">
-                    <input
-                      type="password"
-                      value={this.state.form.password}
-                      onChange={(event) => {
-                        this.updateFormField("password", event.target.value);
-                      }}
-                      className="sl"
-                      name="password"
-                      autoCorrect="off"
-                      spellCheck="false"
-                      autoCapitalize="off"
-                      style={{ width: Setting.PcBrowser ? "280px" : "100%" }}
-                    />
-                  </td>
-                </tr>
-                <tr>
-                  <td width="120" align="right" />
-                  <td width="auto" align="left">
-                    <input type="hidden" value="83861" name="once" />
-                    <input
-                      type="submit"
-                      className="super normal button"
-                      value={i18next.t("general:Sign In")}
+      <Container BreakpointStage={this.props.BreakpointStage}>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            width: "100%",
+            alignItems: "center",
+          }}
+        >
+          <div style={{ width: "100%", marginTop: "10px" }}>
+            {this.renderProblem()}
+            {this.renderMessage()}
+          </div>
+          <div
+            className={`${this.props.BreakpointStage}`}
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              marginBottom: "20px",
+            }}
+          >
+            <div style={{ flex: "1" }}>
+              <Card style={{ textAlign: "left", marginTop: "30px" }}>
+                <div>
+                  <div className="title">
+                    {i18next.t("general:Sign in")} {authConfig.appName}
+                  </div>
+
+                  <form onSubmit={this.onSignin}>
+                    <div>
+                      <input
+                        type="text"
+                        value={this.state.form.information}
+                        onChange={(event) => {
+                          this.updateFormField(
+                            "information",
+                            event.target.value
+                          );
+                        }}
+                        className="input"
+                        name="username"
+                        autoFocus="autofocus"
+                        autoCorrect="off"
+                        spellCheck="false"
+                        autoCapitalize="off"
+                        placeholder={i18next.t(
+                          "general:Username, email address or phone number"
+                        )}
+                      />
+                    </div>
+                    <div>
+                      <input
+                        type="password"
+                        value={this.state.form.password}
+                        onChange={(event) => {
+                          this.updateFormField("password", event.target.value);
+                        }}
+                        className="input"
+                        name="password"
+                        autoCorrect="off"
+                        spellCheck="false"
+                        autoCapitalize="off"
+                        placeholder={i18next.t("general:Password")}
+                      />
+                    </div>
+
+                    <Button
+                      htmlType="submit"
                       onClick={(event) => this.onSignin(event)}
-                    />
-                  </td>
-                </tr>
-                <tr>
-                  <td width="120" align="right" />
-                  <td width="auto" align="left">
-                    <a
-                      href={`${AuthConfig.serverUrl}/forget/${AuthConfig.appName}`}
+                      block="true"
+                      type="primary"
+                      className="button"
                     >
-                      {i18next.t("general:Forgot Password")}
-                    </a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <input type="hidden" value="/signup" name="next" />
-          </form>
+                      {i18next.t("general:Sign In")}
+                    </Button>
+
+                    <input type="hidden" value="/signup" name="next" />
+                  </form>
+                </div>
+              </Card>
+
+              <Card style={{ marginTop: "30px" }}>{this.renderProvider()}</Card>
+            </div>
+            {this.renderRightBar()}
+          </div>
         </div>
-      </div>
+      </Container>
     );
   }
 }

--- a/src/main/TopicList.css
+++ b/src/main/TopicList.css
@@ -1,0 +1,74 @@
+.listBox {
+  display: flex;
+  min-height: 85px;
+  border-bottom: 1px solid #f4f4f4;
+  padding: 15px 25px;
+}
+
+.listBox:hover {
+  background-color: #f9f9f9;
+}
+
+.avatar {
+  padding-top: 6px;
+  margin-right: 8px;
+  min-width: 48px;
+}
+
+.content {
+  flex: 1 1;
+  text-align: left;
+  text-decoration: none;
+  margin: 0;
+  min-width: none;
+  max-width: none;
+}
+
+.title {
+  font-size: 18px;
+  margin-bottom: 0;
+  color: #404040;
+}
+.node {
+  margin-right: 4px;
+  color: #666666;
+}
+
+.info {
+  color: #adaaa8;
+  font-size: 15px;
+  margin-top: 0;
+}
+
+.user {
+  color: #797776;
+  text-decoration: underline;
+  text-decoration-color: rgba(74, 74, 74, 0.3686274509803922);
+}
+
+.count {
+  width: 100px;
+  text-align: right;
+  padding-top: 1.25rem;
+}
+
+.count a {
+  color: #666;
+  line-height: 11px;
+  font-size: 13px;
+  min-width: 32px;
+  text-align: center;
+  border-radius: 80px;
+  padding: 3px 8px;
+  display: inline-block;
+  text-decoration: none;
+  background: rgba(79, 147, 248, 0.24);
+}
+
+.count a:hover {
+  background: #f2f2f2;
+}
+
+.count a:visited {
+  background: #f2f2f2;
+}

--- a/src/main/TopicList.js
+++ b/src/main/TopicList.js
@@ -19,6 +19,8 @@ import Avatar from "../Avatar";
 import "../node.css";
 import i18next from "i18next";
 import { Link } from "react-router-dom";
+
+import "./TopicList.css";
 const pangu = require("pangu");
 
 class TopicList extends React.Component {
@@ -70,156 +72,78 @@ class TopicList extends React.Component {
 
   renderTopic(topic) {
     const pcBrowser = Setting.PcBrowser;
-    const style = this.topStyle(
-      topic?.nodeTopTime,
-      topic?.tabTopTime,
-      topic?.homePageTopTime
-    );
 
     return (
-      <div
-        key={topic?.id}
-        className={`cell item ${this.props.nodeId}`}
-        style={style}
+      <Link
+        to={`/t/${topic?.id}`}
+        onClick={() => this.addTopicHitCount(topic?.id)}
+        className={`${this.props.nodeId}`}
       >
-        <table cellPadding="0" cellSpacing="0" border="0" width="100%">
-          <tbody>
-            <tr>
-              {this.props.showAvatar ? (
-                <td
-                  width={Setting.PcBrowser ? "48" : "24"}
-                  valign="top"
-                  align="center"
+        <div key={topic?.id} className="listBox">
+          <div className="avatar">
+            <Avatar
+              username={topic?.author}
+              avatar={topic?.avatar}
+              size={Setting.PcBrowser ? "" : "medium"}
+            />
+          </div>
+
+          <div className="content">
+            <div className="title">
+              <span className="node">
+                <Link to={`/go/${topic.nodeId}`}>{topic.nodeName}</Link>
+              </span>
+              {pangu.spacing(topic.title)}
+            </div>
+
+            <div className="info">
+              <span className="user">
+                <Link
+                  to={`/member/${topic.author}`}
+                  className={`${this.props.nodeId} member`}
                 >
-                  <Avatar
-                    username={topic?.author}
-                    avatar={topic?.avatar}
-                    size={Setting.PcBrowser ? "" : "small"}
-                  />
-                </td>
-              ) : null}
-              {this.props.showAvatar ? <td width="10" /> : null}
-              <td width="auto" valign="middle">
-                {!pcBrowser && this.props.showNodeName ? (
-                  <span className="small fade">
-                    <Link to={`/go/${topic.nodeId}`} className="node">
-                      {topic.nodeName}
-                    </Link>{" "}
-                    &nbsp;•&nbsp;{" "}
-                    <strong>
-                      <Link to={`/member/${topic.author}`} className="node">
-                        {topic.author}
-                      </Link>
-                    </strong>
+                  {topic.author}
+                </Link>
+              </span>{" "}
+              {pcBrowser ? (
+                <span>
+                  &nbsp;•&nbsp;{" "}
+                  <span className="time">
+                    {topic.lastReplyTime === "" ||
+                    this.props.timeStandard === "createdTime"
+                      ? Setting.getPrettyDate(topic.createdTime)
+                      : Setting.getPrettyDate(topic.lastReplyTime)}
                   </span>
-                ) : null}
-                {!pcBrowser && this.props.showNodeName ? (
-                  <div className="sep5" />
-                ) : null}
-                <span className="item_title">
-                  <Link
-                    to={`/t/${topic?.id}`}
-                    onClick={() => this.addTopicHitCount(topic?.id)}
-                    className={`topic-link b ${this.props.nodeId}`}
-                  >
-                    {pangu.spacing(topic.title)}
-                  </Link>
-                </span>
-                <div className="sep5" />
-                <span className={pcBrowser ? "topic_info" : "small fade"}>
-                  {pcBrowser ? (
-                    <span>
-                      <div className="votes" />
-                      {this.props.showNodeName ? (
-                        <span>
-                          <Link to={`/go/${topic.nodeId}`} className="node">
-                            {topic.nodeName}
-                          </Link>{" "}
-                          &nbsp;•&nbsp;{" "}
-                        </span>
-                      ) : null}
-                      <strong>
+                  {topic.lastReplyUser === "" ? null : (
+                    <div style={{ display: "inline" }}>
+                      {" "}
+                      &nbsp;•&nbsp; {i18next.t("topic:last reply from")}{" "}
+                      <span className="user">
                         <Link
-                          to={`/member/${topic.author}`}
+                          to={`/member/${topic.lastReplyUser}`}
                           className={`${this.props.nodeId} member`}
                         >
-                          {topic.author}
+                          {topic.lastReplyUser}
                         </Link>
-                      </strong>{" "}
-                      &nbsp;•&nbsp;{" "}
-                      {topic.lastReplyTime === "" ||
-                      this.props.timeStandard === "createdTime"
-                        ? Setting.getPrettyDate(topic.createdTime)
-                        : Setting.getPrettyDate(topic.lastReplyTime)}
-                      {topic.lastReplyUser === "" ? null : (
-                        <div style={{ display: "inline" }}>
-                          {" "}
-                          &nbsp;•&nbsp; {i18next.t(
-                            "topic:last reply from"
-                          )}{" "}
-                          <strong>
-                            <Link
-                              to={`/member/${topic.lastReplyUser}`}
-                              className={`${this.props.nodeId} member`}
-                            >
-                              {topic.lastReplyUser}
-                            </Link>
-                          </strong>
-                        </div>
-                      )}
-                    </span>
-                  ) : (
-                    <span>
-                      {this.props.showNodeName ? (
-                        <span>
-                          {topic.lastReplyTime === "" ||
-                          this.props.timeStandard === "createdTime"
-                            ? Setting.getPrettyDate(topic.createdTime)
-                            : Setting.getPrettyDate(topic.lastReplyTime)}
-                          {topic.lastReplyUser === "" ? null : (
-                            <div style={{ display: "inline" }}>
-                              {" "}
-                              &nbsp;•&nbsp; {i18next.t(
-                                "topic:last reply from"
-                              )}{" "}
-                              <strong>
-                                <Link
-                                  to={`/member/${topic.lastReplyUser}`}
-                                  className={`${this.props.nodeId} member`}
-                                >
-                                  {topic.lastReplyUser}
-                                </Link>
-                              </strong>
-                            </div>
-                          )}
-                        </span>
-                      ) : (
-                        <span>
-                          <strong>{topic.author}</strong> &nbsp;•&nbsp;{" "}
-                          {topic.contentLength} {i18next.t("topic:words")}{" "}
-                          &nbsp;•&nbsp; {topic.hitCount}{" "}
-                          {i18next.t("topic:hits")}
-                        </span>
-                      )}
-                    </span>
+                      </span>
+                    </div>
                   )}
                 </span>
-              </td>
-              <td width="70" align="right" valign="middle">
-                {topic.replyCount === 0 ? null : (
-                  <Link
-                    to={`/t/${topic?.id}`}
-                    onClick={() => this.addTopicHitCount(topic?.id)}
-                    className={`count_livid ${this.props.nodeId}`}
-                  >
-                    {topic.replyCount}
-                  </Link>
-                )}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+              ) : null}
+            </div>
+          </div>
+          <div className="count">
+            {topic.replyCount === 0 ? null : (
+              <Link
+                to={`/t/${topic?.id}`}
+                onClick={() => this.addTopicHitCount(topic?.id)}
+              >
+                {topic.replyCount}
+              </Link>
+            )}
+          </div>
+        </div>
+      </Link>
     );
   }
 

--- a/src/node.css
+++ b/src/node.css
@@ -18,6 +18,10 @@
   background-repeat: repeat-x;
 }
 
+#Wrapper {
+  background-color: #f4f4f4;
+}
+
 .nodejs.node_header {
   background-color: #aaaaaa;
 }

--- a/src/rightbar/RightSigninBox.js
+++ b/src/rightbar/RightSigninBox.js
@@ -17,6 +17,9 @@ import { withRouter, Link } from "react-router-dom";
 import * as Auth from "../auth/Auth";
 import i18next from "i18next";
 import "./rightSignin.css";
+import { AuthConfig } from "../Conf";
+
+import { Card } from "antd";
 
 class RightSigninBox extends React.Component {
   constructor(props) {
@@ -83,53 +86,58 @@ class RightSigninBox extends React.Component {
   }
 
   render() {
-    if (
-      window.location.pathname === "/signin" &&
-      this.props.OAuthObjects !== undefined &&
-      this.props.OAuthObjects !== null &&
-      this.props.OAuthObjects.length !== 0
-    ) {
-      return (
-        <div className="box">
-          <div className="header">{i18next.t("bar:Other Sign In Methods")}</div>
-          {this.props.OAuthObjects.map((obj) => {
-            switch (obj.type) {
-              case "Google":
-                return this.renderGoogleSignin(obj.link);
-              case "GitHub":
-                return this.renderGithubSignin(obj.link);
-              case "WeChat":
-                return this.renderWechatSignin(obj.link);
-              case "QQ":
-                return this.renderQQSignin(obj.link);
-              default:
-                return null;
-            }
-          })}
-        </div>
-      );
-    }
+    // if (
+    //   window.location.pathname === "/signin" &&
+    //   this.props.OAuthObjects !== undefined &&
+    //   this.props.OAuthObjects !== null &&
+    //   this.props.OAuthObjects.length !== 0
+    // ) {
+    //   return (
+    //     <div className="box">
+    //       <div className="header">{i18next.t("bar:Other Sign In Methods")}</div>
+    //       {this.props.OAuthObjects.map((obj) => {
+    //         switch (obj.type) {
+    //           case "Google":
+    //             return this.renderGoogleSignin(obj.link);
+    //           case "GitHub":
+    //             return this.renderGithubSignin(obj.link);
+    //           case "WeChat":
+    //             return this.renderWechatSignin(obj.link);
+    //           case "QQ":
+    //             return this.renderQQSignin(obj.link);
+    //           default:
+    //             return null;
+    //         }
+    //       })}
+    //     </div>
+    //   );
+    // }
 
     return (
-      <div className="box">
+      // <div className="box">
+      <Card>
         <div className="cell">
           <strong>Casbin = way to authorization</strong>
           <div className="sep5" />
           <span className="fade">A place for Casbin developers and users</span>
         </div>
-        <div className="inner">
-          <div className="sep5" />
-          <div align="center">
-            <a href={Auth.getSignupUrl()} className="super normal button">
-              {i18next.t("bar:Sign Up Now")}
-            </a>
-            <div className="sep5" />
-            <div className="sep10" />
-            {i18next.t("bar:For Existing Member")} &nbsp;
-            <a href={Auth.getSigninUrl()}>{i18next.t("bar:Sign In")}</a>
-          </div>
-        </div>
-      </div>
+        <div className="sep5" />
+        <ul style={{ listStyle: "none", textAlign: "left", fontSize: "18px" }}>
+          <li>
+            <div style={{ padding: "10px 20px" }}>
+              <a href={Auth.getSignupUrl()}>{i18next.t("bar:Sign Up Now")}</a>
+            </div>
+          </li>
+          <li>
+            <div style={{ padding: "10px 20px" }}>
+              <a href={`${AuthConfig.serverUrl}/forget/${AuthConfig.appName}`}>
+                {i18next.t("general:Forgot Password")}
+              </a>
+            </div>
+          </li>
+        </ul>
+      </Card>
+      // </div>
     );
   }
 }


### PR DESCRIPTION
# changes

## footer that wrapped by container, so it's width is equal to header, and will equal to content area in the future
![image](https://user-images.githubusercontent.com/63595854/129189121-634fea30-ace4-4b02-9f48-6226eecc87fb.png)

## sign up page
![image](https://user-images.githubusercontent.com/63595854/129189292-6d9990e5-2f78-4f9f-b788-7b4d7dd20fed.png)

## topiclist
![image](https://user-images.githubusercontent.com/63595854/129189367-3007596d-b767-47e7-8b51-ef0ad70f81c9.png)

## replybox
![image](https://user-images.githubusercontent.com/63595854/129189491-dd68bb99-8c7b-441c-a489-b1161ba647ba.png)

## demo
http://39.106.18.82/